### PR TITLE
[14] Workaround fix for hardcoded backend URL

### DIFF
--- a/Assets/Visualiser/Scripts/ScenesCoordinator.cs
+++ b/Assets/Visualiser/Scripts/ScenesCoordinator.cs
@@ -73,7 +73,7 @@ public class ScenesCoordinator : MonoBehaviour
         formData.Add(new MultipartFormDataSection("url", customSolverDomain));
         //serialize form fields into byte[] => requires a bounday to put in between fields
         byte[] formSections = UnityWebRequest.SerializeFormSections(formData, boundary);
-        UnityWebRequest www = UnityWebRequest.Post("http://127.0.0.1:8000/upload/pddl", formData);
+        UnityWebRequest www = UnityWebRequest.Post("/upload/pddl", formData);
 		//UnityWebRequest www = UnityWebRequest.Post("https://planning-visualisation-solver.herokuapp.com//upload/pddl", formData);
 		www.uploadHandler =  new UploadHandlerRaw(formSections);
 		www.SetRequestHeader("Content-Type", "multipart/form-data; boundary="+ Encoding.UTF8.GetString(boundary));


### PR DESCRIPTION
This is workaround quick fix to use front proxy to redirect `/upload/pddl` to backend `:8000`